### PR TITLE
Task 1448: Changed location and references of copy-button

### DIFF
--- a/src/copy-button.tsx
+++ b/src/copy-button.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import styled from 'styled-components'
-import { Copy } from '../icons'
-import { Td } from './elements'
+import { Copy } from './icons'
 
 const Button = styled.div`
   cursor: pointer;
@@ -26,7 +25,8 @@ const Tooltip = styled.div`
   background: #fff;
   border: var(--border);
   border-radius: var(--border-radius);
-  bottom: 25px;
+  bottom: -10px;
+  left: 150%;
   box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
   padding: 10px;
   position: absolute;
@@ -41,7 +41,6 @@ const Input = styled.input`
   height: 1px;
   width: 1px;
 `
-
 type Props<T> = {
   row: T
   valueAccessor: (row: T) => string
@@ -57,7 +56,6 @@ export default class<T> extends React.Component<Props<T>, State> {
 
   constructor(props: Props<T>) {
     super(props)
-
     this.state = {
       status: 'Copy for TTB',
     }
@@ -91,13 +89,13 @@ export default class<T> extends React.Component<Props<T>, State> {
 
   render() {
     return (
-      <Td>
+      <div>
         <Input innerRef={input => (this.input = input)} />
         <Button onClick={this.copyToClipboard}>
           <Tooltip>{this.state.status}</Tooltip>
           <Copy />
         </Button>
-      </Td>
+      </div>
     )
   }
 }

--- a/src/table/group.tsx
+++ b/src/table/group.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
+import CopyButton from '../copy-button'
 import TableCell from './cell'
-import CopyButton from './copy-button'
-import { Tr } from './elements'
+import { Td, Tr } from './elements'
 import { Column, Row } from './model'
 import TableRow from './row'
 import RowSelector from './row-selector'
@@ -40,7 +40,9 @@ export default function<T extends Row>({
           />
         )}
         {clipboardValue && (
-          <CopyButton row={group} valueAccessor={clipboardValue} />
+          <Td>
+            <CopyButton row={group} valueAccessor={clipboardValue} />
+          </Td>
         )}
         {columns.map(column => (
           <TableCell

--- a/src/table/row.tsx
+++ b/src/table/row.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
+import CopyButton from '../copy-button'
 import TableCell from './cell'
-import CopyButton from './copy-button'
 import { Td, Tr } from './elements'
 import { Column, Row } from './model'
 import RowSelector from './row-selector'
@@ -37,7 +37,9 @@ export default function<T extends Row>({
       )}
       {hideClipboardCopy && <Td />}
       {clipboardValue && (
-        <CopyButton row={row} valueAccessor={clipboardValue} />
+        <Td>
+          <CopyButton row={row} valueAccessor={clipboardValue} />
+        </Td>
       )}
       {columns.map(column => (
         <TableCell


### PR DESCRIPTION
(Wrong name of feature. Branch 1488 should have been named 1448)
- Removed td elements in copy-button and replaced with divs
- Wrapped copy-button with td elements in the table component
